### PR TITLE
Fix/serialization

### DIFF
--- a/djangoyearlessdate/models.py
+++ b/djangoyearlessdate/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from helpers import YearlessDate
 import forms
 
+
 class YearlessDateField(models.Field):
     "A model field for storing dates without years"
     description = "A date without a year, for use in things like birthdays"
@@ -24,34 +25,36 @@ class YearlessDateField(models.Field):
         # The string case.
         return YearlessDate(value[2:], value[:2])
 
-    
     def get_prep_value(self, value):
         "The reverse of to_python, for inserting into the database"
         if value is not None:
             return ''.join(["%02d" % i for i in (value.month, value.day)])
-    
+
     def get_internal_type(self):
         return 'CharField'
-    
+
     def value_to_string(self, obj):
         "For serialization"
         value = self._get_val_from_obj(obj)
         return self.get_db_prep_value(value)
-    
+
     def formfield(self, **kwargs):
         # This is a fairly standard way to set up some defaults
         # while letting the caller override them.
         defaults = {'form_class': forms.YearlessDateField}
         defaults.update(kwargs)
         return super(YearlessDateField, self).formfield(**defaults)
-    
+
+
 class YearField(models.IntegerField):
     "A model field for storing years, e.g. 2012"
+
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.YearField}
         defaults.update(kwargs)
         return super(YearField, self).formfield(**defaults)
-    
+
+
 #South integration
 try:
     from south.modelsinspector import add_introspection_rules

--- a/djangoyearlessdate/models.py
+++ b/djangoyearlessdate/models.py
@@ -33,11 +33,6 @@ class YearlessDateField(models.Field):
     def get_internal_type(self):
         return 'CharField'
 
-    def value_to_string(self, obj):
-        "For serialization"
-        value = self._get_val_from_obj(obj)
-        return self.get_db_prep_value(value)
-
     def formfield(self, **kwargs):
         # This is a fairly standard way to set up some defaults
         # while letting the caller override them.


### PR DESCRIPTION
Using django==1.11.8 and djangorestframework==3.6.4 I'm having issues when serializing the values using the field as `self.get_db_prep_value(...)` requires a connection argument.

The `self._get_val_from_obj(obj)` call is also deprecated and using the base `value_to_string` seems to work.